### PR TITLE
Fix Jitpack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,4 @@
-before_install:
-  - wget https://immortaldevs.net/install-jdk.sh
-  - source install-jdk.sh --feature 17
+jdk:
+  - openjdk17
 env:
   ENVIRONMENT: "production"


### PR DESCRIPTION
Updated the jitpack.yml file to simply use OpenJDK17 instead of the Immortal Devs script, which has been removed