### PR TITLE
Add Jade and WTHIT plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ repositories {
 	mavenCentral()
 	maven { url "https://maven.shedaniel.me/" }
 	maven { url "https://maven.terraformersmc.com" }
+	maven { url "https://api.modrinth.com/maven/" }
+	maven { url "https://maven2.bai.lol" }
 }
 
 dependencies {
@@ -27,6 +29,9 @@ dependencies {
 
 	// dependencies
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	modCompileOnly "maven.modrinth:jade:${project.jade_version}"
+	modCompileOnly "mcp.mobius.waila:wthit-api:fabric-${project.wthit_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ archives_base_name = revelationary
 
 # https://fabricmc.net/develop/
 fabric_version=0.90.0+1.20.1
+
+jade_version=QhvPNPdp
+wthit_version=8.5.0

--- a/src/main/java/de/dafuqs/revelationary/compat/jade/RevelationaryJadePlugin.java
+++ b/src/main/java/de/dafuqs/revelationary/compat/jade/RevelationaryJadePlugin.java
@@ -1,0 +1,31 @@
+package de.dafuqs.revelationary.compat.jade;
+
+import de.dafuqs.revelationary.api.revelations.RevelationAware;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaPlugin;
+
+public class RevelationaryJadePlugin implements IWailaPlugin {
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.addRayTraceCallback((hitResult, accessor, originalAccessor) -> {
+            if (accessor instanceof BlockAccessor blockAccessor) {
+                PlayerEntity player = accessor.getPlayer();
+                if (player.isCreative() || player.isSpectator()) {
+                    return accessor;
+                }
+
+                if (blockAccessor.getBlock() instanceof RevelationAware aware) {
+                    if (!aware.isVisibleTo(player)) {
+                        BlockState cloakedState = aware.getBlockStateCloaks().get(blockAccessor.getBlockState());
+                        return registration.blockAccessor().from(blockAccessor).blockState(cloakedState).build();
+                    }
+                }
+            }
+
+            return accessor;
+        });
+    }
+}

--- a/src/main/java/de/dafuqs/revelationary/compat/wthit/CloakedBlockComponentProvider.java
+++ b/src/main/java/de/dafuqs/revelationary/compat/wthit/CloakedBlockComponentProvider.java
@@ -1,0 +1,23 @@
+package de.dafuqs.revelationary.compat.wthit;
+
+import de.dafuqs.revelationary.api.revelations.RevelationAware;
+import mcp.mobius.waila.api.IBlockAccessor;
+import mcp.mobius.waila.api.IBlockComponentProvider;
+import mcp.mobius.waila.api.IPluginConfig;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import org.jetbrains.annotations.Nullable;
+
+public class CloakedBlockComponentProvider implements IBlockComponentProvider {
+    @Override
+    public @Nullable BlockState getOverride(IBlockAccessor accessor, IPluginConfig config) {
+        PlayerEntity player = accessor.getPlayer();
+
+        RevelationAware aware = (RevelationAware) accessor.getBlock();
+        if (!aware.isVisibleTo(player)) {
+            return aware.getBlockStateCloaks().get(accessor.getBlockState());
+        }
+
+        return accessor.getBlockState();
+    }
+}

--- a/src/main/java/de/dafuqs/revelationary/compat/wthit/RevelationaryWthitPlugin.java
+++ b/src/main/java/de/dafuqs/revelationary/compat/wthit/RevelationaryWthitPlugin.java
@@ -1,0 +1,12 @@
+package de.dafuqs.revelationary.compat.wthit;
+
+import de.dafuqs.revelationary.api.revelations.RevelationAware;
+import mcp.mobius.waila.api.IRegistrar;
+import mcp.mobius.waila.api.IWailaPlugin;
+
+public class RevelationaryWthitPlugin implements IWailaPlugin {
+    @Override
+    public void register(IRegistrar registrar) {
+        registrar.addOverride(new CloakedBlockComponentProvider(), RevelationAware.class);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,9 @@
     ],
     "client": [
       "de.dafuqs.revelationary.RevelationaryClient"
+    ],
+    "jade": [
+      "de.dafuqs.revelationary.compat.jade.RevelationaryJadePlugin"
     ]
   },
   "mixins": [

--- a/src/main/resources/wthit_plugins.json
+++ b/src/main/resources/wthit_plugins.json
@@ -1,0 +1,5 @@
+{
+  "revelationary:plugin": {
+    "initializer": "de.dafuqs.revelationary.compat.wthit.RevelationaryWthitPlugin"
+  }
+}


### PR DESCRIPTION
Display cloaked blocks as their disguise when the player hasn't revealed them yet.

Follows convention set by the respective mod whether to show disguise in creative/spectator mode or not.