### PR TITLE
JEI fixes

### DIFF
--- a/src/main/java/de/dafuqs/revelationary/api/revelations/CloakSetChanged.java
+++ b/src/main/java/de/dafuqs/revelationary/api/revelations/CloakSetChanged.java
@@ -1,16 +1,22 @@
 package de.dafuqs.revelationary.api.revelations;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.Item;
 
 import java.util.Set;
 
+@Environment(EnvType.CLIENT)
 @FunctionalInterface
 public interface CloakSetChanged {
     Event<CloakSetChanged> EVENT = EventFactory.createArrayBacked(CloakSetChanged.class,
             (listeners) -> (addedCloaks, removedCloaks, newCloaks) -> {
-                for (CloakSetChanged listener : listeners) listener.onChange(addedCloaks, removedCloaks, newCloaks);
+                MinecraftClient.getInstance().execute(() -> {
+                    for (CloakSetChanged listener : listeners) listener.onChange(addedCloaks, removedCloaks, newCloaks);
+                });
             });
     // the diffs matter for JEI, the new cloaks set matters for REI
     void onChange(Set<Item> addedCloaks, Set<Item> removedCloaks, Set<Item> newCloaks);

--- a/src/main/java/de/dafuqs/revelationary/compat/jei/RevelationaryJEIPlugin.java
+++ b/src/main/java/de/dafuqs/revelationary/compat/jei/RevelationaryJEIPlugin.java
@@ -24,10 +24,12 @@ public class RevelationaryJEIPlugin implements IModPlugin {
             stacksCache = newStacks;
             if (runtime != null) {
                 var manager = runtime.getIngredientManager();
-                manager.removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK,
-                        added.stream().map(ItemStack::new).collect(Collectors.toList()));
-                manager.addIngredientsAtRuntime(VanillaTypes.ITEM_STACK,
-                        removed.stream().map(ItemStack::new).collect(Collectors.toList()));
+                if(added != null && !added.isEmpty())
+                    manager.removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK,
+                            added.stream().map(ItemStack::new).collect(Collectors.toList()));
+                if(removed != null && !removed.isEmpty())
+                    manager.addIngredientsAtRuntime(VanillaTypes.ITEM_STACK,
+                            removed.stream().map(ItemStack::new).collect(Collectors.toList()));
             }
         });
     }
@@ -41,7 +43,7 @@ public class RevelationaryJEIPlugin implements IModPlugin {
     public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
         runtime = jeiRuntime;
         if (!RevelationaryConfig.get().HideCloakedEntriesFromRecipeViewers) return;
-        if (stacksCache != null) runtime.getIngredientManager()
+        if (stacksCache != null && !stacksCache.isEmpty()) runtime.getIngredientManager()
                 .removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK,
                         stacksCache.stream().map(ItemStack::new).collect(Collectors.toList()));
     }

--- a/src/main/java/de/dafuqs/revelationary/compat/rei/RevelationaryREIPlugin.java
+++ b/src/main/java/de/dafuqs/revelationary/compat/rei/RevelationaryREIPlugin.java
@@ -28,8 +28,8 @@ public class RevelationaryREIPlugin implements REIClientPlugin {
     @Override
     public void registerBasicEntryFiltering(@SuppressWarnings("UnstableApiUsage") BasicFilteringRule<?> rule) {
         // not using .show to not interfere with other filtering rules
-        //noinspection UnstableApiUsage
         if (!RevelationaryConfig.get().HideCloakedEntriesFromRecipeViewers) return;
+        //noinspection UnstableApiUsage
         filteringRule = rule.hide(() ->
             hiddenStacks.stream()
                     .map(EntryStacks::of)


### PR DESCRIPTION
Turns out, JEI has a few additional requirements for (un)hiding items, which have gone completely unnoticed during the development of the JEI & REI entry hiding feature, and for a long time since its deployment ~~(since nobody uses JEI anyway)~~
This fix accounts for both of the requirements of needing to be executed in the main client thread and not passing empty lists.