### PR TITLE
Fix cloaking an item as itself

### DIFF
--- a/src/main/java/de/dafuqs/revelationary/mixin/client/BlockModelsMixin.java
+++ b/src/main/java/de/dafuqs/revelationary/mixin/client/BlockModelsMixin.java
@@ -26,7 +26,7 @@ public class BlockModelsMixin {
 	
 	@Inject(at = @At("HEAD"), method = "getModel", cancellable = true)
 	private void getModel(BlockState blockState, CallbackInfoReturnable<BakedModel> callbackInfoReturnable) {
-		if (ClientRevelationHolder.isCloaked(blockState)) {
+		if (ClientRevelationHolder.isCloaked(blockState) && !ClientRevelationHolder.getCloakTarget(blockState).equals(blockState)) {
 			BlockState destinationBlockState = ClientRevelationHolder.getCloakTarget(blockState);
 			BakedModel overriddenModel = this.models.getOrDefault(destinationBlockState, modelManager.getMissingModel());
 			callbackInfoReturnable.setReturnValue(overriddenModel);

--- a/src/main/java/de/dafuqs/revelationary/mixin/client/ItemModelsMixin.java
+++ b/src/main/java/de/dafuqs/revelationary/mixin/client/ItemModelsMixin.java
@@ -22,7 +22,7 @@ public abstract class ItemModelsMixin {
 
     @Inject(at = @At("HEAD"), method = "getModel(Lnet/minecraft/item/ItemStack;)Lnet/minecraft/client/render/model/BakedModel;", cancellable = true)
     private void revelationary$getModel(ItemStack itemStack, CallbackInfoReturnable<BakedModel> callbackInfoReturnable) {
-        if (ClientRevelationHolder.isCloaked(itemStack.getItem())) {
+        if (ClientRevelationHolder.isCloaked(itemStack.getItem()) && !ClientRevelationHolder.getCloakTarget(itemStack.getItem()).equals(itemStack.getItem())) {
             Item destinationItem = ClientRevelationHolder.getCloakTarget(itemStack.getItem());
             BakedModel overriddenModel = getModel(destinationItem.getDefaultStack());
             callbackInfoReturnable.setReturnValue(overriddenModel);


### PR DESCRIPTION
Added a check to both item and block model cloaking to ensure they only actually run if the models are different. Before this change, trying to do this would crash with a stack overflow error,,,