### PR TITLE
disable HideCloakedEntriesFromRecipeViewers by default

### DIFF
--- a/src/main/java/de/dafuqs/revelationary/config/RevelationaryConfig.java
+++ b/src/main/java/de/dafuqs/revelationary/config/RevelationaryConfig.java
@@ -22,7 +22,7 @@ public class RevelationaryConfig {
 	public static class Config {
 		public boolean PreventMiningOfUnrevealedBlocks = false;
 		public boolean UseTargetBlockOrItemNameInsteadOfScatter = false;
-		public boolean HideCloakedEntriesFromRecipeViewers = true;
+		public boolean HideCloakedEntriesFromRecipeViewers = false;
 		public String NameForUnrevealedBlocks = "";
 		public String NameForUnrevealedItems = "";
 


### PR DESCRIPTION
completely breaks with JEI, and causes other confusing behaviors.